### PR TITLE
fixed the program crash when minimize the window

### DIFF
--- a/example02_pipelineAndRayGen/SampleRenderer.cpp
+++ b/example02_pipelineAndRayGen/SampleRenderer.cpp
@@ -379,6 +379,9 @@ namespace osc {
   /*! resize frame buffer to given resolution */
   void SampleRenderer::resize(const vec2i &newSize)
   {
+    // if window minimized
+    if (newSize.x == 0 | newSize.y == 0) return;
+    
     // resize our cuda frame buffer
     colorBuffer.resize(newSize.x*newSize.y*sizeof(uint32_t));
 

--- a/example03_inGLFWindow/SampleRenderer.cpp
+++ b/example03_inGLFWindow/SampleRenderer.cpp
@@ -379,6 +379,9 @@ namespace osc {
   /*! resize frame buffer to given resolution */
   void SampleRenderer::resize(const vec2i &newSize)
   {
+    // if window minimized
+    if (newSize.x == 0 | newSize.y == 0) return;
+    
     // resize our cuda frame buffer
     colorBuffer.resize(newSize.x*newSize.y*sizeof(uint32_t));
 

--- a/example04_firstTriangleMesh/SampleRenderer.cpp
+++ b/example04_firstTriangleMesh/SampleRenderer.cpp
@@ -560,6 +560,9 @@ namespace osc {
   /*! resize frame buffer to given resolution */
   void SampleRenderer::resize(const vec2i &newSize)
   {
+    // if window minimized
+    if (newSize.x == 0 | newSize.y == 0) return;
+    
     // resize our cuda frame buffer
     colorBuffer.resize(newSize.x*newSize.y*sizeof(uint32_t));
 

--- a/example05_firstSBTData/SampleRenderer.cpp
+++ b/example05_firstSBTData/SampleRenderer.cpp
@@ -558,6 +558,9 @@ namespace osc {
   /*! resize frame buffer to given resolution */
   void SampleRenderer::resize(const vec2i &newSize)
   {
+    // if window minimized
+    if (newSize.x == 0 | newSize.y == 0) return;
+    
     // resize our cuda frame buffer
     colorBuffer.resize(newSize.x*newSize.y*sizeof(uint32_t));
 

--- a/example06_multipleObjects/SampleRenderer.cpp
+++ b/example06_multipleObjects/SampleRenderer.cpp
@@ -570,6 +570,9 @@ namespace osc {
   /*! resize frame buffer to given resolution */
   void SampleRenderer::resize(const vec2i &newSize)
   {
+    // if window minimized
+    if (newSize.x == 0 | newSize.y == 0) return;
+    
     // resize our cuda frame buffer
     colorBuffer.resize(newSize.x*newSize.y*sizeof(uint32_t));
 

--- a/example07_firstRealModel/SampleRenderer.cpp
+++ b/example07_firstRealModel/SampleRenderer.cpp
@@ -530,6 +530,9 @@ namespace osc {
   /*! resize frame buffer to given resolution */
   void SampleRenderer::resize(const vec2i &newSize)
   {
+    // if window minimized
+    if (newSize.x == 0 | newSize.y == 0) return;
+    
     // resize our cuda frame buffer
     colorBuffer.resize(newSize.x*newSize.y*sizeof(uint32_t));
 

--- a/example08_addingTextures/SampleRenderer.cpp
+++ b/example08_addingTextures/SampleRenderer.cpp
@@ -600,6 +600,9 @@ namespace osc {
   /*! resize frame buffer to given resolution */
   void SampleRenderer::resize(const vec2i &newSize)
   {
+    // if window minimized
+    if (newSize.x == 0 | newSize.y == 0) return;
+    
     // resize our cuda frame buffer
     colorBuffer.resize(newSize.x*newSize.y*sizeof(uint32_t));
 

--- a/example09_shadowRays/SampleRenderer.cpp
+++ b/example09_shadowRays/SampleRenderer.cpp
@@ -644,6 +644,9 @@ namespace osc {
   /*! resize frame buffer to given resolution */
   void SampleRenderer::resize(const vec2i &newSize)
   {
+    // if window minimized
+    if (newSize.x == 0 | newSize.y == 0) return;
+    
     // resize our cuda frame buffer
     colorBuffer.resize(newSize.x*newSize.y*sizeof(uint32_t));
 

--- a/example10_softShadows/SampleRenderer.cpp
+++ b/example10_softShadows/SampleRenderer.cpp
@@ -650,6 +650,9 @@ namespace osc {
   /*! resize frame buffer to given resolution */
   void SampleRenderer::resize(const vec2i &newSize)
   {
+    // if window minimized
+    if (newSize.x == 0 | newSize.y == 0) return;
+    
     // resize our cuda frame buffer
     colorBuffer.resize(newSize.x*newSize.y*sizeof(uint32_t));
 


### PR DESCRIPTION
So, under windows 10, if you try to minimize the GLFW window or use short cut Alt + Tab to navigate between windows, the program will crash due to the operating system seems to return a 0 window size.

This is a simple fix for this frustrating problem.

Beside this pull request, I want to give my thanks to this OptiX tutorial, best I can find on the Internet. 

Here is my personal project based on this tutorial. I rewrite the CMake script and make it can both compiled by MSVC 2019 and Clang 10 on windows. Add some features like use 'WSAD' to navigate in the scene; a 360 degree camera (which can't work quite properly now). Try it if anyone is interest.
https://github.com/gzfrozen/EM_tracing