### PR TITLE
fix example11 denoiserOptions error

### DIFF
--- a/example11_denoiseColorOnly/SampleRenderer.cpp
+++ b/example11_denoiseColorOnly/SampleRenderer.cpp
@@ -718,12 +718,14 @@ namespace osc {
     // ------------------------------------------------------------------
     // create the denoiser:
     OptixDenoiserOptions denoiserOptions = {};
+
+    denoiserOptions.inputKind = OPTIX_DENOISER_INPUT_RGB;
+
 #if OPTIX_VERSION < 70100
     // these only exist in 7.0, not 7.1
-    denoiserOptions.inputKind   = OPTIX_DENOISER_INPUT_RGB;
     denoiserOptions.pixelFormat = OPTIX_PIXEL_FORMAT_FLOAT4;
 #endif
-    
+
     OPTIX_CHECK(optixDenoiserCreate(optixContext,&denoiserOptions,&denoiser));
     OPTIX_CHECK(optixDenoiserSetModel(denoiser,OPTIX_DENOISER_MODEL_KIND_LDR,NULL,0));
     


### PR DESCRIPTION
'pixelFormat' only exist in 7.0 but 'inputKind' both in 7.0 and 7.1. If ‘denoiserOptions.inputKind’ is modified under the conditional branch when OPTIX_VERSION=70100, will make the ‘denoiserOptions’ input empty, causing an error. So I put the statement modified for ‘denoiserOptions.inputKind’ outside the conditional branch.