### PR TITLE
Correctly indent if in ex 02 device code

### DIFF
--- a/example02_pipelineAndRayGen/devicePrograms.cu
+++ b/example02_pipelineAndRayGen/devicePrograms.cu
@@ -75,7 +75,7 @@ namespace osc {
              optixLaunchParams.fbSize.x,
              optixLaunchParams.fbSize.y);
       printf("############################################\n");
-  }
+    }
 
     // ------------------------------------------------------------------
     // for this example, produce a simple test pattern:


### PR DESCRIPTION
As of now, the closing curly brace of an `if` statement inside the `__raygen__renderFrame()` function in the `devicePrograms.cu` file of the second example is indented two spaces less than it should be, making it look like the `__raygen__renderFrame()` function's  losing curly brace at first sight. This commit indents it correctly such that its role is not misunderstood.

It's a very small thing but I hope it helps!