### PR TITLE
fix example 12 denoiserOptions error

### DIFF
--- a/example12_denoiseSeparateChannels/SampleRenderer.cpp
+++ b/example12_denoiseSeparateChannels/SampleRenderer.cpp
@@ -626,6 +626,8 @@ namespace osc {
                             1
                             ));
 
+    denoiserIntensity.resize(sizeof(float));
+
     OptixDenoiserParams denoiserParams;
     denoiserParams.denoiseAlpha = 1;
     denoiserParams.hdrIntensity = denoiserIntensity.d_pointer();
@@ -755,9 +757,10 @@ namespace osc {
     // ------------------------------------------------------------------
     // create the denoiser:
     OptixDenoiserOptions denoiserOptions = {};
+    denoiserOptions.inputKind = OPTIX_DENOISER_INPUT_RGB_ALBEDO;
+
 #if OPTIX_VERSION < 70100
     // these only exist in 7.0, not 7.1
-    denoiserOptions.inputKind   = OPTIX_DENOISER_INPUT_RGB;
     denoiserOptions.pixelFormat = OPTIX_PIXEL_FORMAT_FLOAT4;
 #endif
     


### PR DESCRIPTION
Related Issue: #9 

**Description**

Fixed the issue that is similar to commit #4 but for example 12.
I pulled the line out of the conditional branch but also had to use `OPTIX_DENOISER_INPUT_RGB_ALBEDO` instead of `OPTIX_DENOISER_INPUT_RGB` because example 12 uses two channels for denoising. 
