### PR TITLE
Add all relevant header files to each project's CMakeLists file

### DIFF
--- a/example02_pipelineAndRayGen/CMakeLists.txt
+++ b/example02_pipelineAndRayGen/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(ex02_pipelineAndRayGen
   ${embedded_ptx_code}
   optix7.h
   CUDABuffer.h
+  LaunchParams.h
   SampleRenderer.h
   SampleRenderer.cpp
   main.cpp

--- a/example03_inGLFWindow/CMakeLists.txt
+++ b/example03_inGLFWindow/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(ex03_testFrameInWindow
   ${embedded_ptx_code}
   optix7.h
   CUDABuffer.h
+  LaunchParams.h
   SampleRenderer.h
   SampleRenderer.cpp
   main.cpp

--- a/example04_firstTriangleMesh/CMakeLists.txt
+++ b/example04_firstTriangleMesh/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(ex04_firstTriangleMesh
   ${embedded_ptx_code}
   optix7.h
   CUDABuffer.h
+  LaunchParams.h
   SampleRenderer.h
   SampleRenderer.cpp
   main.cpp

--- a/example05_firstSBTData/CMakeLists.txt
+++ b/example05_firstSBTData/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(ex05_firstSBTData
   ${embedded_ptx_code}
   optix7.h
   CUDABuffer.h
+  LaunchParams.h
   SampleRenderer.h
   SampleRenderer.cpp
   main.cpp

--- a/example06_multipleObjects/CMakeLists.txt
+++ b/example06_multipleObjects/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(ex06_multipleObjects
   ${embedded_ptx_code}
   optix7.h
   CUDABuffer.h
+  LaunchParams.h
   SampleRenderer.h
   SampleRenderer.cpp
   main.cpp

--- a/example07_firstRealModel/CMakeLists.txt
+++ b/example07_firstRealModel/CMakeLists.txt
@@ -24,8 +24,10 @@ add_executable(ex07_firstRealModel
   ${embedded_ptx_code}
   optix7.h
   CUDABuffer.h
+  LaunchParams.h
   SampleRenderer.h
   SampleRenderer.cpp
+  Model.h
   Model.cpp
   main.cpp
   )

--- a/example08_addingTextures/CMakeLists.txt
+++ b/example08_addingTextures/CMakeLists.txt
@@ -24,8 +24,10 @@ add_executable(ex08_addingTextures
   ${embedded_ptx_code}
   optix7.h
   CUDABuffer.h
+  LaunchParams.h
   SampleRenderer.h
   SampleRenderer.cpp
+  Model.h
   Model.cpp
   main.cpp
   )

--- a/example09_shadowRays/CMakeLists.txt
+++ b/example09_shadowRays/CMakeLists.txt
@@ -24,8 +24,10 @@ add_executable(ex09_shadowRays
   ${embedded_ptx_code}
   optix7.h
   CUDABuffer.h
+  LaunchParams.h
   SampleRenderer.h
   SampleRenderer.cpp
+  Model.h
   Model.cpp
   main.cpp
   )

--- a/example10_softShadows/CMakeLists.txt
+++ b/example10_softShadows/CMakeLists.txt
@@ -24,8 +24,10 @@ add_executable(ex10_softShadows
   ${embedded_ptx_code}
   optix7.h
   CUDABuffer.h
+  LaunchParams.h
   SampleRenderer.h
   SampleRenderer.cpp
+  Model.h
   Model.cpp
   main.cpp
   )

--- a/example11_denoiseColorOnly/CMakeLists.txt
+++ b/example11_denoiseColorOnly/CMakeLists.txt
@@ -24,8 +24,10 @@ add_executable(ex11_denoiseColorOnly
   ${embedded_ptx_code}
   optix7.h
   CUDABuffer.h
+  LaunchParams.h
   SampleRenderer.h
   SampleRenderer.cpp
+  Model.h
   Model.cpp
   main.cpp
   )

--- a/example12_denoiseSeparateChannels/CMakeLists.txt
+++ b/example12_denoiseSeparateChannels/CMakeLists.txt
@@ -27,8 +27,10 @@ add_executable(ex12_denoiseSeparateChannels
   devicePrograms.cu
   optix7.h
   CUDABuffer.h
+  LaunchParams.h
   SampleRenderer.h
   SampleRenderer.cpp
+  Model.h
   Model.cpp
   main.cpp
   )


### PR DESCRIPTION
This obviously isn't a problem for the compiler, but it was confusing to work in Visual Studio and not be able to see all the project files in the solution explorer.