### PR TITLE
Fix casting error from int to OPTIX_DENOISER_ALPHA_MODE_ALPHA_AS_AOV

### DIFF
--- a/example11_denoiseColorOnly/SampleRenderer.cpp
+++ b/example11_denoiseColorOnly/SampleRenderer.cpp
@@ -627,7 +627,7 @@ namespace osc {
                             ));
 
     OptixDenoiserParams denoiserParams;
-    denoiserParams.denoiseAlpha = 1;
+    denoiserParams.denoiseAlpha = OPTIX_DENOISER_ALPHA_MODE_ALPHA_AS_AOV;
     denoiserParams.hdrIntensity = (CUdeviceptr)0;
     if (accumulate)
         denoiserParams.blendFactor = 1.f / (launchParams.frame.frameID);

--- a/example12_denoiseSeparateChannels/SampleRenderer.cpp
+++ b/example12_denoiseSeparateChannels/SampleRenderer.cpp
@@ -629,7 +629,7 @@ namespace osc {
     denoiserIntensity.resize(sizeof(float));
 
     OptixDenoiserParams denoiserParams;
-    denoiserParams.denoiseAlpha = 1;
+    denoiserParams.denoiseAlpha = OPTIX_DENOISER_ALPHA_MODE_ALPHA_AS_AOV;
 #if OPTIX_VERSION >= 70300
     if (denoiserIntensity.sizeInBytes != sizeof(float))
         denoiserIntensity.alloc(sizeof(float));


### PR DESCRIPTION
When compiling with gcc 9.4.0, denoiser examples 11 and 12 fail with:

```
error: invalid conversion from ‘int’ to ‘OptixDenoiserAlphaMode’ [-fpermissive]
      denoiserParams.denoiseAlpha = 1;
```

Use the actual enumeration type `OPTIX_DENOISER_ALPHA_MODE_ALPHA_AS_AOV` instead, which fixes the error and is more verbose.
